### PR TITLE
Fix cpu affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 11. May 2024
+
+* Nail the current process/thread to one specific CPU core (the first core), if the chosen method is PTE remapping. The issue was that if the CPU scheduler throws the process/thread from the core n, and later resumes execution on core m, with a different CPU cache, the PTE remapping method can return wrong read data.
+* This is needed only for the PTE remapping method, not for the Microsoft-implemented method using the physical memory device. It is assumed that Microsoft implemented everything correctly and thus needs no such attention(?).
+* Corrected the old typo in the title and added a limitation section. Reading **physical** memory larger than 7fffffffffffffff will fail due to the current OS design of Microsoft,which restricts the I/O read request to not specify anything larger than a (positive) int64 value.
+
 ### 27. Nov 2022, 3.0.3 *alpha*
 
 No bugs detected anymore, only small improvements, testing (and knowledge increase). 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The WinPmem memory acquisition driver and userspace.
+# WinPmem -- a physical memory acquisition tool
 
 ![alt text](site/figures/128x128/winpmem_with_eye.png "WinPmem -- a physical memory acquisition tool")
 
@@ -71,6 +71,10 @@ To acquire a raw image using specifically the MmMapIoSpace method:
 `winpmem.exe -1 myimage.raw`
 
 The driver will be automatically unloaded after the image is acquired!
+
+### Limitations
+
+Due to how Microsoft designed the MJ READ function, reading from physical memory will fail in Winpmem with STATUS_INVALID_PARAMETER if a physical address *larger* than half the maximum value of an UINT64 is specified. E.g., this is true if somebody wants to read in higher parts of the physical memory **and** has a giant physical memory (more than 9,223,372,036,854,775,807). This sounds highly unlikely, but todays RAM sizes continue to increase.
 
 Experimental write support
 --------------------------


### PR DESCRIPTION
Nail CPU Affinity for PTE method to avoid being re-scheduled at any time during PTE remapping on another Core.