### PR TITLE
Clean code tiny update

### DIFF
--- a/src/winpmem.c
+++ b/src/winpmem.c
@@ -59,9 +59,9 @@ VOID IoUnload(IN PDRIVER_OBJECT DriverObject)
 
     // Checking every object allows to call the IoUnload routine from DriverEntry at any point for cleaning/freeing whatever needs to be freed/cleaned.
 
-    if ((SIZE_T) pDeviceObject > ValidKernel)
+    if ((SIZE_T) pDeviceObject > (SIZE_T) MM_SYSTEM_RANGE_START)
     {
-        ASSERT((SIZE_T) pDeviceObject->DeviceExtension > ValidKernel); // does not happen.
+        ASSERT((SIZE_T) pDeviceObject->DeviceExtension > (SIZE_T) MM_SYSTEM_RANGE_START); // does not happen.
         ext = (PDEVICE_EXTENSION) pDeviceObject->DeviceExtension;
 
         #if defined(_WIN64)
@@ -72,7 +72,7 @@ VOID IoUnload(IN PDRIVER_OBJECT DriverObject)
         RtlInitUnicodeString (&DeviceLinkUnicodeString, L"\\??\\" PMEM_DEVICE_NAME);
         IoDeleteSymbolicLink (&DeviceLinkUnicodeString);
 
-        if ((SIZE_T) (DriverObject->FastIoDispatch) > ValidKernel)
+        if ((SIZE_T) (DriverObject->FastIoDispatch) > (SIZE_T) MM_SYSTEM_RANGE_START)
         {
             ExFreePool(DriverObject->FastIoDispatch);
         }
@@ -425,7 +425,7 @@ NTSTATUS wddDispatchDeviceControl(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP
         PTE_STATUS pte_status = PTE_SUCCESS;
         VIRT_ADDR In_VA;
         volatile PPTE pPTE;
-        PHYS_ADDR Out_PhysAddr;
+        PHYS_ADDR Out_PhysAddr = 0;
         ULONG page_offset;
 
         if (!ext->pte_data.pte_method_is_ready_to_use)

--- a/src/winpmem.h
+++ b/src/winpmem.h
@@ -41,13 +41,6 @@
 
 #include "pte_mmap.h"
 
-// slightly enhanced non-null pointer checking / kernel address space sanity checking.
-#if defined(_WIN64)
-SIZE_T ValidKernel = 0xffff000000000000;
-#else
-SIZE_T ValidKernel = 0x80000000;
-#endif
-
 #define DEFAULT_SIZE_STR (250)
 DECLARE_UNICODE_STRING_SIZE(eventLogKeyEntry, DEFAULT_SIZE_STR);
 


### PR DESCRIPTION
* Corrected: consistent behavior on the `PHYS_ADDR Out_PhysAddr` out variable, use MS clean code standard ("always initialize out variables"). (Thanks for hinting out!)
* Changed kernel boundary check (in Unload) to use the header definition instead of using an own hardcoded value. (Thanks for hinting out, nicer this way!)