### PR TITLE
Clean code updates, a bug fix, and more ranges

### DIFF
--- a/src/userspace_interface/winpmem_shared.h
+++ b/src/userspace_interface/winpmem_shared.h
@@ -26,38 +26,39 @@ typedef unsigned __int8 u8;
 #define PMEM_MODE_PTE 2
 // #define PMEM_MODE_PTE_PCI 3 // deprecated
 
-#define NUMBER_OF_RUNS   (20)
+#define NUMBER_OF_RUNS   (300)  // increased allowed size. Backward compability should be given, since the array is at the end. 
 
 #pragma pack(push, 2)
 
 
+// For programmers, please do not rely on unchangeability of this struct and be prepared that this struct might change.
+// It contains too much deprecated data.
+
 typedef struct _WINPMEM_MEMORY_INFO
 {
-  LARGE_INTEGER CR3;
+  LARGE_INTEGER CR3;  // System process Cr3.
   LARGE_INTEGER NtBuildNumber; // Version of this kernel.
 
   LARGE_INTEGER KernBase;  // The base of the kernel image.
 
 
-  // The following are deprecated and will not be set by the driver. It is safer
-  // to get these during analysis from NtBuildNumberAddr below.
-  LARGE_INTEGER KDBG;  // xxx: I want that. Can I have it?
-
-  // xxx: Support up to 32/64  processors for KPCR. Depending on OS bitness
+  // The following are deprecated and will not be set by the driver. 
+  
+  LARGE_INTEGER KDBG;  // Deprecated since a long time now. 
+  
   #if defined(_WIN64)
-  LARGE_INTEGER KPCR[64];
+  LARGE_INTEGER KPCR[64]; // still filled out pro forma
   #else
-  LARGE_INTEGER KPCR[32];
+  LARGE_INTEGER KPCR[32];  // still filled out pro forma
   #endif
 
-  LARGE_INTEGER PfnDataBase;
-  LARGE_INTEGER PsLoadedModuleList;
-  LARGE_INTEGER PsActiveProcessHead;
+  LARGE_INTEGER PfnDataBase;  // Deprecated since a long time now. 
+  LARGE_INTEGER PsLoadedModuleList;  // Deprecated since a long time now. 
+  LARGE_INTEGER PsActiveProcessHead;  // Deprecated since a long time now. 
 
   // END DEPRECATED.
 
-  // The address of the NtBuildNumber integer - could be used to find the kernel base.
-  LARGE_INTEGER NtBuildNumberAddr;
+  LARGE_INTEGER NtBuildNumberAddr;  // still filled out pro forma.
 
   // As the driver is extended we can add fields here maintaining
   // driver alignment..

--- a/src/winpmem.h
+++ b/src/winpmem.h
@@ -41,13 +41,6 @@
 
 #include "pte_mmap.h"
 
-// slightly enhanced non-null pointer checking / kernel address space sanity checking.
-#if defined(_WIN64)
-SIZE_T ValidKernel = 0xffff000000000000;
-#else
-SIZE_T ValidKernel = 0x80000000;
-#endif
-
 #define DEFAULT_SIZE_STR (250)
 DECLARE_UNICODE_STRING_SIZE(eventLogKeyEntry, DEFAULT_SIZE_STR);
 


### PR DESCRIPTION
* Corrected: consistent behavior on the `PHYS_ADDR Out_PhysAddr` out variable, use MS clean code standard ("always initialize out variables"). (Thanks for hinting out!)
* Changed kernel boundary check (in Unload) to use the header definition instead of using an own hardcoded value. (Thanks for hinting out, nicer this way!)
* Important: goto exit was missing in an error condition in the reverse query ioctl.
* More Physical Ranges allowed by Winpmem. "300 ought to be enough for everybody!"